### PR TITLE
Fix path for loading planets data in Orrery component

### DIFF
--- a/src/routes/Orrery/Orrery.tsx
+++ b/src/routes/Orrery/Orrery.tsx
@@ -29,7 +29,7 @@ export const Orrery = () => {
 
     useEffect(() => {
         if (trajectories.planets.length === 0) {
-            TrajectoryUtils.load("/data/planets.json").then(planets => {
+            TrajectoryUtils.load("/sac25/data/planets.json").then(planets => {
                 setTrajectories({
                     ...trajectories,
                     planets


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the planets.json loading path to /sac25/data/planets.json in Orrery